### PR TITLE
Fix condition syntax in alerts template for invalid sample (#156)

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 2.7.0 (unreleased)
 ------------------
 
+- #156 Fix condition syntax in alerts template for invalid sample
 - #155 Support for analysis conditions
 - #153 Update ReactJS 18 -> 19
 - #152 jQuery3 compatibility

--- a/src/senaite/impress/analysisrequest/templates/alerts.pt
+++ b/src/senaite/impress/analysisrequest/templates/alerts.pt
@@ -8,7 +8,7 @@
           <h2 class="alert-heading"><span tal:replace="model/getId"/></h2>
           <div i18n:translate="">This Analysis Request has been invalidated due to erroneously published results</div>
           <tal:invalidreport tal:define="child python:model.getRetest()"
-                             tal:condition="child">
+                             tal:condition="python:child">
             <span i18n:translate="">This Analysis request has been replaced by</span>
             <a tal:attributes="href child/absolute_url"
                tal:content="child/getId"></a>


### PR DESCRIPTION
* Fix condition syntax in alerts template for invalid sample

* Changelog

## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.impress/issues/

## Current behavior before PR

## Desired behavior after PR is merged

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
